### PR TITLE
Use HTTPS endpoints

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -29,12 +29,12 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     /**
      * @var string
      */
-    protected $releasesUrlFormat = 'http://connect20.magentocommerce.com/community/%s/releases.xml';
+    protected $releasesUrlFormat = 'https://connect20.magentocommerce.com/community/%s/releases.xml';
 
     /**
      * @var string
      */
-    protected $distUrlFormat = 'http://connect20.magentocommerce.com/community/%s/%s/%s-%s.tgz';
+    protected $distUrlFormat = 'https://connect20.magentocommerce.com/community/%s/%s/%s-%s.tgz';
 
     /**
      * @var string


### PR DESCRIPTION
Composer seems to have moved to secure transport by default. While I've not found any issues from having this as HTTP I think it's probably best to be secure :smile: 
